### PR TITLE
Update Loader.php

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -14,7 +14,6 @@ class Loader
 
     public function __construct()
     {
-        $this->getDefaultFile();
         $this->getFile();
         $this->load();
     }
@@ -33,7 +32,9 @@ class Loader
     protected function getDefaultFile()
     {
         $result = glob(get_stylesheet_directory() . '/bundle.*');
-        return $result[0];
+        $result = empty($result) ? : $result[0];
+        
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Correction of a small error.

When installing the plugin, if there is no `bundle.*` file in the stylesheets directory, then we get the **Notice: Undefined offset**, even if we use the `sober/bundle/file` filter.

These changes solve this problem.